### PR TITLE
[FEAT] ARCHIVE-58 feat: 댓글 crud 추가

### DIFF
--- a/src/main/java/com/ssafy/ssafy_13ban_archive/post/controller/CommentController.java
+++ b/src/main/java/com/ssafy/ssafy_13ban_archive/post/controller/CommentController.java
@@ -1,0 +1,76 @@
+package com.ssafy.ssafy_13ban_archive.post.controller;
+
+import com.ssafy.ssafy_13ban_archive.common.model.reponse.CommonResponse;
+import com.ssafy.ssafy_13ban_archive.common.model.reponse.SuccessResponseDTO;
+import com.ssafy.ssafy_13ban_archive.post.model.request.CommentRequestDTO;
+import com.ssafy.ssafy_13ban_archive.post.model.response.CommentResponseDTO;
+import com.ssafy.ssafy_13ban_archive.post.service.CommentService;
+import com.ssafy.ssafy_13ban_archive.security.dto.JwtUserInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/post/{postId}/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // 댓글 생성
+    @Operation(summary = "댓글 생성", description = "게시글에 댓글을 작성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 생성 성공")
+    })
+    @PostMapping
+    public CommonResponse<CommentResponseDTO> createComment(
+            @PathVariable Integer postId,
+            @RequestBody CommentRequestDTO request,
+            @AuthenticationPrincipal JwtUserInfo jwtUserInfo
+    ) {
+        Integer userId = jwtUserInfo.getUserId(); // JwtUserInfo는 getUserId() 사용
+        return new CommonResponse<>(
+                commentService.createComment(postId, userId, request),
+                HttpStatus.OK
+        );
+    }
+
+    // 댓글 수정
+    @Operation(summary = "댓글 수정", description = "댓글 내용을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
+    })
+    @PutMapping("/{commentId}")
+    public CommonResponse<CommentResponseDTO> updateComment(
+            @PathVariable Integer postId,
+            @PathVariable Integer commentId,
+            @RequestBody CommentRequestDTO request,
+            @AuthenticationPrincipal JwtUserInfo jwtUserInfo
+    ) {
+        Integer userId = jwtUserInfo.getUserId(); // 수정
+        return new CommonResponse<>(
+                commentService.updateComment(postId, commentId, userId, request),
+                HttpStatus.OK
+        );
+    }
+
+    // 댓글 삭제
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 삭제 성공")
+    })
+    @DeleteMapping("/{commentId}")
+    public CommonResponse<SuccessResponseDTO> deleteComment(
+            @PathVariable Integer postId,
+            @PathVariable Integer commentId,
+            @AuthenticationPrincipal JwtUserInfo jwtUserInfo
+    ) {
+        Integer userId = jwtUserInfo.getUserId(); // 수정
+        boolean result = commentService.deleteComment(postId, commentId, userId);
+        return new CommonResponse<>(new SuccessResponseDTO(result), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/ssafy/ssafy_13ban_archive/post/model/request/CommentRequestDTO.java
+++ b/src/main/java/com/ssafy/ssafy_13ban_archive/post/model/request/CommentRequestDTO.java
@@ -1,0 +1,18 @@
+package com.ssafy.ssafy_13ban_archive.post.model.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentRequestDTO {
+
+    @Schema(description = "댓글 내용", example = "이 게시글 정말 유익하네요!")
+    @NotBlank(message = "댓글 내용은 비어 있을 수 없습니다.")
+    private String content;
+
+}

--- a/src/main/java/com/ssafy/ssafy_13ban_archive/post/model/response/CommentResponseDTO.java
+++ b/src/main/java/com/ssafy/ssafy_13ban_archive/post/model/response/CommentResponseDTO.java
@@ -1,0 +1,28 @@
+package com.ssafy.ssafy_13ban_archive.post.model.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentResponseDTO {
+
+    private Integer commentId;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Integer postId;
+
+    private Integer userId;
+
+}

--- a/src/main/java/com/ssafy/ssafy_13ban_archive/post/repository/CommentRepository.java
+++ b/src/main/java/com/ssafy/ssafy_13ban_archive/post/repository/CommentRepository.java
@@ -1,0 +1,16 @@
+package com.ssafy.ssafy_13ban_archive.post.repository;
+
+import com.ssafy.ssafy_13ban_archive.post.model.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Integer> {
+
+    // 특정 게시글(postId)에 달린 모든 댓글 조회 (최신순 정렬 등은 서비스단에서 처리 가능)
+    List<Comment> findByPostId(Integer postId);
+
+    // (선택) 특정 유저가 쓴 댓글 모두 조회
+    List<Comment> findByUserId(Integer userId);
+
+}

--- a/src/main/java/com/ssafy/ssafy_13ban_archive/post/service/CommentService.java
+++ b/src/main/java/com/ssafy/ssafy_13ban_archive/post/service/CommentService.java
@@ -1,0 +1,91 @@
+package com.ssafy.ssafy_13ban_archive.post.service;
+
+import com.ssafy.ssafy_13ban_archive.post.model.entity.Comment;
+import com.ssafy.ssafy_13ban_archive.post.model.entity.Post;
+import com.ssafy.ssafy_13ban_archive.post.model.request.CommentRequestDTO;
+import com.ssafy.ssafy_13ban_archive.post.model.response.CommentResponseDTO;
+import com.ssafy.ssafy_13ban_archive.post.repository.CommentRepository;
+import com.ssafy.ssafy_13ban_archive.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    /**
+     * 댓글 생성
+     */
+    @Transactional
+    public CommentResponseDTO createComment(Integer postId, Integer userId, CommentRequestDTO request) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        Comment comment = Comment.builder()
+                .postId(postId)
+                .userId(userId)
+                .content(request.getContent())
+                .build();
+
+        Comment saved = commentRepository.save(comment);
+        return toResponseDTO(saved);
+    }
+
+    /**
+     * 댓글 수정
+     */
+    @Transactional
+    public CommentResponseDTO updateComment(Integer postId, Integer commentId, Integer userId, CommentRequestDTO request) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        if (!comment.getPostId().equals(postId)) {
+            throw new IllegalArgumentException("게시글에 해당하는 댓글이 아닙니다.");
+        }
+
+        if (!comment.getUserId().equals(userId)) {
+            throw new SecurityException("본인이 작성한 댓글만 수정할 수 있습니다.");
+        }
+
+        comment.setContent(request.getContent());
+        return toResponseDTO(comment);
+    }
+
+    /**
+     * 댓글 삭제
+     */
+    @Transactional
+    public boolean deleteComment(Integer postId, Integer commentId, Integer userId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        if (!comment.getPostId().equals(postId)) {
+            throw new IllegalArgumentException("게시글에 해당하는 댓글이 아닙니다.");
+        }
+
+        if (!comment.getUserId().equals(userId)) {
+            throw new SecurityException("본인이 작성한 댓글만 삭제할 수 있습니다.");
+        }
+
+        commentRepository.delete(comment);
+        return true;
+    }
+
+    /**
+     * 응답 DTO로 변환
+     */
+    private CommentResponseDTO toResponseDTO(Comment comment) {
+        return CommentResponseDTO.builder()
+                .commentId(comment.getCommentId())
+                .content(comment.getContent())
+                .createdAt(null) // 혹시 createdAt 필드가 없을 수도 있으니 일단 null 처리
+                .updatedAt(null)
+                .postId(comment.getPostId())
+                .userId(comment.getUserId())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📎 연관된 이슈
- ARCHIVE-58

---

## 📝 작업 내용
- [x] 댓글 생성 API 구현 (`POST /api/v1/post/{postId}/comment`)
- [x] 댓글 수정 API 구현 (`PUT /api/v1/post/{postId}/comment/{commentId}`)
- [x] 댓글 삭제 API 구현 (`DELETE /api/v1/post/{postId}/comment/{commentId}`)
- [x] CommentController, CommentService 로직 분리
- [x] JwtUserInfo를 활용한 사용자 인증 연동

---

## 🧾 작업 상세 내용
- `CommentRequestDTO`, `CommentResponseDTO` 생성
- `CommentRepository` JPA 인터페이스 정의
- 댓글 수정 및 삭제 시 사용자 본인 여부 검증 로직 적용
- Swagger 문서화 적용 (@Operation 등)
